### PR TITLE
Get Player Latency from souce engine

### DIFF
--- a/CornerCulling/CullingController.cpp
+++ b/CornerCulling/CullingController.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include "CullingIO.h"
 
+#include "../extension.h"
+
 CullingController::CullingController() {}
 
 void CullingController::BeginPlay(char* mapName)
@@ -114,6 +116,20 @@ void CullingController::PopulateBundles()
 //   Integrate with server latency estimation tools.
 int CullingController::GetLatency(int i)
 {
+    IGamePlayer *pPlayer = playerhelpers->GetGamePlayer(i);
+    if (!pPlayer)
+	{
+		return 200;
+	}
+	else if (!pPlayer->IsConnected())
+	{
+		return 200;
+	}
+	else if (pPlayer->IsFakeClient())
+	{
+		return 0;
+	};
+
     return 200;
 }
 

--- a/CornerCulling/FastBVH/Traverser.h
+++ b/CornerCulling/FastBVH/Traverser.h
@@ -86,7 +86,7 @@ namespace FastBVH {
     {
         // Pop off the next node to work on.
         int ni = todo[stackptr].i;
-        Float near = todo[stackptr].mint;
+        Float nearest = todo[stackptr].mint;
         stackptr--;
         const auto& node(nodes[ni]);
 


### PR DESCRIPTION
This will get the average roundtrip time for clients when calculating culling. 
The latest roundtrip time could also be used but that would be more jittery. 